### PR TITLE
Update sbt-pgp version to v0.8.2

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.7")
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.2")


### PR DESCRIPTION
because of sbt-pgp v0.7 is not for sbt-0.13.x

```
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: com.typesafe.sbt#sbt-pgp;0.7: not found
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn] 
[warn]  Note: Some unresolved dependencies have extra attributes.  Check that these dependencies exist with the requested attributes.
[warn]      com.typesafe.sbt:sbt-pgp:0.7 (sbtVersion=0.13, scalaVersion=2.10)
```
