### PR TITLE
Using container-based infrastructure on Travis CI build job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ jdk:
 services:
   - memcached
 
-before_script:
-  - sh src/test/resources/setup_travis.sh
+env:
+  - TEST_MEMCACHED_HOST=127.0.0.1 TEST_MEMCACHED_PORT=11211

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ jdk:
   - oraclejdk7
   - openjdk7
 
+sudo: false
+
 services:
   - memcached
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,8 +19,10 @@ organization := "com.dongxiguo"
 
 version := "0.3.3-SNAPSHOT"
 
-libraryDependencies +=
-  "com.novocode" % "junit-interface" % "0.7" % "test->default"
+libraryDependencies ++= Seq(
+  "com.novocode" % "junit-interface" % "0.7" % "test->default",
+  "com.typesafe" % "config" % "1.2.1" % "test"
+)
 
 libraryDependencies <++= scalaBinaryVersion {
   case "2.10" => {

--- a/src/test/resources/setup_travis.sh
+++ b/src/test/resources/setup_travis.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-sudo sh -c 'echo "127.0.0.1 tt.btplug.dongxiguo.com" >> /etc/hosts'
-
-sudo sed -i -e 's/-p 11211/-p 1978/' /etc/memcached.conf
-
-sudo service memcached restart

--- a/src/test/resources/test.conf
+++ b/src/test/resources/test.conf
@@ -1,0 +1,8 @@
+memcontinuationed {
+  memcached {
+    host = "tt.btplug.dongxiguo.com"
+    host = ${?TEST_MEMCACHED_HOST}
+    port = 1978
+    port = ${?TEST_MEMCACHED_PORT}
+  }
+}

--- a/src/test/scala/com/dongxiguo/memcontinuationed/TestServerAddress.scala
+++ b/src/test/scala/com/dongxiguo/memcontinuationed/TestServerAddress.scala
@@ -17,13 +17,15 @@
 package com
 package dongxiguo
 package memcontinuationed
+import com.typesafe.config.ConfigFactory
 import java.net.InetSocketAddress
 
 object TestServerAddress {
+  private[this] lazy val conf = ConfigFactory.load("test")
 
   /**
    * 根据键确定数据在哪个服务器上
    */
   final def getAddress(accessor: StorageAccessor[_]) =
-    new InetSocketAddress("tt.btplug.dongxiguo.com", 1978)
+    new InetSocketAddress(conf.getString("memcontinuationed.memcached.host"), conf.getInt("memcontinuationed.memcached.port"))
 }


### PR DESCRIPTION
Specify `sudo: false` to use container-based infrastructure on Travis CI.
https://docs.travis-ci.com/user/workers/container-based-infrastructure/

It's hard for me to modify [setup_travis.sh](https://github.com/Atry/memcontinuationed/blob/2738a3609ffcd4cde2fe375fc13c8a22d2b24fbc/src/test/resources/setup_travis.sh) without `sudo`,
so I define memcached host and port in the config file to switch by env var.
